### PR TITLE
Fix: mag-sh folder in dependabot automated scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,7 @@ updates:
       timezone: "Europe/Amsterdam"
 
   - package-ecosystem: docker
-    directory: /mag-sh
+    directory: /magsh
     schedule:
       interval: weekly
       day: thursday


### PR DESCRIPTION
The folder was set as mag-sh and it is magsh